### PR TITLE
Implement P2000 app skeleton

### DIFF
--- a/P2000App/Sources/P2000App/Models/P2000Message.swift
+++ b/P2000App/Sources/P2000App/Models/P2000Message.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct P2000Feed: Decodable {
+    let messages: [P2000Message]
+}
+
+struct P2000Message: Identifiable, Decodable {
+    let id: String
+    let title: String
+    let service: EmergencyService
+    let timestamp: Date
+    let latitude: Double?
+    let longitude: Double?
+    let description: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id = "id"
+        case title = "title"
+        case service = "service"
+        case timestamp = "date"
+        case latitude = "latitude"
+        case longitude = "longitude"
+        case description = "description"
+    }
+}
+
+enum EmergencyService: String, Decodable, CaseIterable, Identifiable {
+    case ambulance = "Ambulance"
+    case fire = "Brandweer"
+    case police = "Politie"
+    case knrm = "KNRM"
+    case other = "Overige"
+
+    var id: String { rawValue }
+}

--- a/P2000App/Sources/P2000App/P2000AppApp.swift
+++ b/P2000App/Sources/P2000App/P2000AppApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct P2000AppApp: App {
+    @StateObject private var store = P2000Store()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(store)
+        }
+    }
+}

--- a/P2000App/Sources/P2000App/Services/P2000Service.swift
+++ b/P2000App/Sources/P2000App/Services/P2000Service.swift
@@ -1,0 +1,14 @@
+import Foundation
+import Combine
+
+struct P2000Service {
+    private let url = URL(string: "https://feeds.veiligheidsregio.net/feeds/p2000.json")!
+
+    func fetchMessages() -> AnyPublisher<[P2000Message], Error> {
+        URLSession.shared.dataTaskPublisher(for: url)
+            .map { $0.data }
+            .decode(type: P2000Feed.self, decoder: JSONDecoder())
+            .map { $0.messages }
+            .eraseToAnyPublisher()
+    }
+}

--- a/P2000App/Sources/P2000App/Services/P2000Store.swift
+++ b/P2000App/Sources/P2000App/Services/P2000Store.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Combine
+
+class P2000Store: ObservableObject {
+    @Published var messages: [P2000Message] = []
+    @Published var filter: EmergencyService? = nil
+
+    private var cancellables = Set<AnyCancellable>()
+    private let service = P2000Service()
+
+    init() {
+        fetchMessages()
+    }
+
+    func fetchMessages() {
+        service.fetchMessages()
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { completion in
+                if case let .failure(error) = completion {
+                    print("Error fetching messages: \(error)")
+                }
+            }, receiveValue: { [weak self] messages in
+                self?.messages = messages
+            })
+            .store(in: &cancellables)
+    }
+}

--- a/P2000App/Sources/P2000App/Views/ContentView.swift
+++ b/P2000App/Sources/P2000App/Views/ContentView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        TabView {
+            HomeView()
+                .tabItem {
+                    Label("Home", systemImage: "list.bullet")
+                }
+
+            MapMessagesView()
+                .tabItem {
+                    Label("Kaart", systemImage: "map")
+                }
+
+            SearchView()
+                .tabItem {
+                    Label("Zoeken", systemImage: "magnifyingglass")
+                }
+
+            SettingsView()
+                .tabItem {
+                    Label("Instellingen", systemImage: "gear")
+                }
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+        .environmentObject(P2000Store())
+}

--- a/P2000App/Sources/P2000App/Views/HomeView.swift
+++ b/P2000App/Sources/P2000App/Views/HomeView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct HomeView: View {
+    @EnvironmentObject var store: P2000Store
+
+    var body: some View {
+        NavigationView {
+            List(filteredMessages) { message in
+                VStack(alignment: .leading) {
+                    Text(message.title)
+                        .font(.headline)
+                    Text(message.timestamp, style: .time)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .navigationTitle("Meldingen")
+            .toolbar {
+                Menu {
+                    Button("Alle", action: { store.filter = nil })
+                    ForEach(EmergencyService.allCases) { service in
+                        Button(service.rawValue, action: { store.filter = service })
+                    }
+                } label: {
+                    Label("Filter", systemImage: "line.3.horizontal.decrease.circle")
+                }
+            }
+        }
+    }
+
+    private var filteredMessages: [P2000Message] {
+        if let filter = store.filter {
+            return store.messages.filter { $0.service == filter }
+        } else {
+            return store.messages
+        }
+    }
+}
+
+#Preview {
+    HomeView()
+        .environmentObject(P2000Store())
+}

--- a/P2000App/Sources/P2000App/Views/MapMessagesView.swift
+++ b/P2000App/Sources/P2000App/Views/MapMessagesView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+import MapKit
+
+struct MapMessagesView: View {
+    @EnvironmentObject var store: P2000Store
+    @State private var hours: Double = 24
+    @State private var region = MKCoordinateRegion(
+        center: CLLocationCoordinate2D(latitude: 52.1, longitude: 5.1),
+        span: MKCoordinateSpan(latitudeDelta: 2.0, longitudeDelta: 2.0)
+    )
+
+    var body: some View {
+        NavigationView {
+            Map(coordinateRegion: $region, annotationItems: recentMessages) { message in
+                MapAnnotation(coordinate: CLLocationCoordinate2D(latitude: message.latitude ?? 0, longitude: message.longitude ?? 0)) {
+                    Circle()
+                        .strokeBorder(Color.blue, lineWidth: 2)
+                        .frame(width: 20, height: 20)
+                        .background(Circle().fill(Color.blue.opacity(0.3)))
+                }
+            }
+            .navigationTitle("Meldingen")
+            .toolbar {
+                ToolbarItem(placement: .bottomBar) {
+                    HStack {
+                        Text("\(Int(hours))u")
+                        Slider(value: $hours, in: 12...168, step: 12)
+                    }
+                }
+            }
+        }
+    }
+
+    private var recentMessages: [P2000Message] {
+        let cutoff = Date().addingTimeInterval(-hours * 3600)
+        return store.messages.filter { $0.timestamp >= cutoff }
+    }
+}
+
+#Preview {
+    MapMessagesView()
+        .environmentObject(P2000Store())
+}

--- a/P2000App/Sources/P2000App/Views/SearchView.swift
+++ b/P2000App/Sources/P2000App/Views/SearchView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct SearchView: View {
+    @EnvironmentObject var store: P2000Store
+    @State private var query = ""
+
+    var body: some View {
+        NavigationView {
+            List(filteredMessages) { message in
+                VStack(alignment: .leading) {
+                    Text(message.title)
+                    Text(message.timestamp, style: .time)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .searchable(text: $query, placement: .automatic)
+            .navigationTitle("Zoeken")
+        }
+    }
+
+    private var filteredMessages: [P2000Message] {
+        if query.isEmpty {
+            return store.messages
+        }
+        return store.messages.filter { message in
+            message.title.localizedCaseInsensitiveContains(query)
+                || message.description?.localizedCaseInsensitiveContains(query) == true
+        }
+    }
+}
+
+#Preview {
+    SearchView()
+        .environmentObject(P2000Store())
+}

--- a/P2000App/Sources/P2000App/Views/SettingsView.swift
+++ b/P2000App/Sources/P2000App/Views/SettingsView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @AppStorage("language") private var language: String = Locale.current.language.languageCode?.identifier ?? "en"
+    @State private var radius: Double = 25
+    @State private var caching: Bool = true
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Taal")) {
+                    Picker("Taal", selection: $language) {
+                        Text("Nederlands").tag("nl")
+                        Text("English").tag("en")
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Section(header: Text("Bereik")) {
+                    HStack {
+                        Slider(value: $radius, in: 5...100, step: 5)
+                        Text("\(Int(radius)) km")
+                    }
+                }
+
+                Section(header: Text("Opslag")) {
+                    Toggle("Caching", isOn: $caching)
+                }
+            }
+            .navigationTitle("Instellingen")
+        }
+    }
+}
+
+#Preview {
+    SettingsView()
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# P2000
-My P2000 app
+# P2000 Meldingen App
+
+Een iOS-app gebouwd in SwiftUI die realtime P2000-meldingen toont. De applicatie gebruikt de JSON-feed van [Veiligheidsregio.net](https://feeds.veiligheidsregio.net/feeds/p2000.json) en presenteert de gegevens in een moderne interface geïnspireerd op het iOS 26 Liquid Glass concept.
+
+## Functionaliteiten
+
+- **Home**: overzicht van de meest recente meldingen met mogelijkheid om te filteren op hulpdienst.
+- **Kaart**: interactieve kaart met meldingen van de afgelopen uren. De gebruiker kan zelf het tijdsvenster instellen.
+- **Zoeken**: zoek meldingen op plaatsnaam of tekst.
+- **Instellingen**: kies taal, pas de straal van meldingen aan en schakel caching in of uit.
+
+De code in deze repository bevat een basisimplementatie van het bovengenoemde concept. Extra functies zoals widgets, live activities en pushmeldingen kunnen hierop verder worden uitgebouwd.


### PR DESCRIPTION
## Summary
- create a basic SwiftUI app skeleton under `P2000App`
- implement model and service for the P2000 feed
- add simple views: Home, Map, Search and Settings
- update README with project info

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68796f11f7a0832a9aa65ec2c5615ff9